### PR TITLE
Possible fix to the selectRangeWithoutCopy function + removal of white space changes

### DIFF
--- a/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
+++ b/src/main/java/org/roaringbitmap/buffer/ImmutableRoaringBitmap.java
@@ -262,8 +262,7 @@ public class ImmutableRoaringBitmap implements Iterable<Integer>, Cloneable, Imm
         if(hbStart == hbLast) {
             final int i = rb.highLowContainer.getIndex((short) hbStart);
             if (i >= 0) {
-                final MappeableContainer c = rb.highLowContainer.getContainerAtIndex(i)
-                        .remove(lbStart, lbLast + 1);
+                final MappeableContainer c = rb.highLowContainer.getContainerAtIndex(i).remove(0,lbStart).remove(lbLast + 1,BufferUtil.maxLowBitAsInteger()+1);
                 if (c.getCardinality() > 0)
                     ((MutableRoaringArray) answer.highLowContainer).append((short) hbStart, c);
             }
@@ -271,9 +270,9 @@ public class ImmutableRoaringBitmap implements Iterable<Integer>, Cloneable, Imm
         }
         int ifirst = rb.highLowContainer.getIndex((short) hbStart);
         int ilast = rb.highLowContainer.getIndex((short) hbLast);
-        if((ifirst >= 0) && (lbStart != 0)) {
+        if(ifirst >= 0) {
             final MappeableContainer c = rb.highLowContainer.getContainerAtIndex(ifirst).remove(
-                     lbStart,BufferUtil.maxLowBitAsInteger()+1);
+                     0,lbStart);
            if(c.getCardinality()>0) {
               ((MutableRoaringArray) answer.highLowContainer).append((short) hbStart, c);
            }
@@ -293,9 +292,9 @@ public class ImmutableRoaringBitmap implements Iterable<Integer>, Cloneable, Imm
             }
         }
         
-        if((ilast >= 0) &&(lbLast != BufferUtil.maxLowBitAsInteger())) {
+        if(ilast >= 0) {
             final MappeableContainer c = rb.highLowContainer.getContainerAtIndex(ilast).remove(
-                     0,  lbLast+1);
+                    lbLast+1,  BufferUtil.maxLowBitAsInteger()+1);
            if(c.getCardinality()>0) {
               ((MutableRoaringArray) answer.highLowContainer).append((short) hbLast,c);
            }

--- a/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -21,770 +21,766 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 
-
 /**
  * Generic testing of the roaring bitmaps
  */
-@SuppressWarnings({ "static-method" })
+@SuppressWarnings({"static-method"})
 public class TestImmutableRoaringBitmap {
-  @Test
-  public void testHighBits() throws IOException {
-    // version without any runcontainers (earlier serialization version)
-    for (int offset = 1 << 14; offset < 1 << 18; offset *= 2) {
-      MutableRoaringBitmap rb = new MutableRoaringBitmap();
-      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
-        rb.add((int) k);
-      }
-      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
-        Assert.assertTrue(rb.contains((int) k));
-      }
-      int[] array = rb.toArray();
-      ByteBuffer b = ByteBuffer.allocate(rb.serializedSizeInBytes());
-      rb.serialize(new DataOutputStream(new OutputStream() {
-        ByteBuffer mBB;
+	@Test
+	public void testHighBits() throws IOException {
+		// version without any runcontainers (earlier serialization version)
+		for (int offset = 1 << 14; offset < 1 << 18; offset *= 2) {
+			MutableRoaringBitmap rb = new MutableRoaringBitmap();
+			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
+				rb.add((int) k);
+			}
+			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
+				Assert.assertTrue(rb.contains((int) k));
+			}
+			int[] array = rb.toArray();
+			ByteBuffer b = ByteBuffer.allocate(rb.serializedSizeInBytes());
+			rb.serialize(new DataOutputStream(new OutputStream() {
+				ByteBuffer mBB;
 
-        OutputStream init(final ByteBuffer mbb) {
-          mBB = mbb;
-          return this;
+				OutputStream init(final ByteBuffer mbb) {
+					mBB = mbb;
+					return this;
+				}
+				
+			    @Override
+				public void close() {
+				}
+			    
+			    @Override
+				public void flush() {
+				}
+			    
+			    @Override
+				public void write(final int b) {
+					mBB.put((byte) b);
+				}
+			    
+			    @Override
+				public void write(final byte[] b) {
+					mBB.put(b);
+				}
+
+			    @Override
+				public void write(final byte[] b, final int off, final int l) {
+					mBB.put(b, off, l);
+				}
+			}.init(b)));
+			b.flip();
+			ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
+			Assert.assertTrue(irb.equals(rb));
+			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
+				Assert.assertTrue(irb.contains((int) k));
+			}
+			Assert.assertTrue(Arrays.equals(array, irb.toArray()));
+		}
+	}
+
+	@SuppressWarnings("resource")
+	@Test
+	public void testHighBitsA() throws IOException {
+		// includes some run containers
+		for (int offset = 1 << 14; offset < 1 << 18; offset *= 2) {
+			MutableRoaringBitmap rb = new MutableRoaringBitmap();
+			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE - 100000; k += offset) {
+				rb.add((int) k);
+			}
+			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE - 100000; k += offset) {
+				Assert.assertTrue(rb.contains((int) k));
+			}
+
+			int runlength=99000;
+			for (int k = Integer.MAX_VALUE - 100000; k < Integer.MAX_VALUE - 100000 +runlength; ++k)
+				rb.add(k);
+
+			rb.runOptimize();
+
+			int[] array = rb.toArray();
+			//int pos = 0;
+			// check that it is in sorted order according to unsigned order
+			for(int k = 0; k < array.length - 1; ++k) {
+				Assert.assertTrue((0xFFFFFFFFL & array[k]) <= (0xFFFFFFFFL & array[k + 1]));
+			}
+			///////////////////////
+			// It was decided that Roaring would consider ints as unsigned
+			///////////////////////
+			//for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE-100000; k += offset) {
+			//	Assert.assertTrue(array[pos++] == (int)k);
+			//}
+			//Assert.assertTrue(pos+runlength == array.length);
+			ByteBuffer b = ByteBuffer.allocate(rb.serializedSizeInBytes());
+			rb.serialize(new DataOutputStream(new OutputStream() {
+				ByteBuffer mBB;
+
+				OutputStream init(final ByteBuffer mbb) {
+					mBB = mbb;
+					return this;
+				}
+				
+			    @Override
+				public void close() {
+				}
+
+			    @Override
+				public void flush() {
+				}
+
+			    @Override
+				public void write(final int b) {
+					mBB.put((byte) b);
+				}
+			    
+			    @Override
+				public void write(final byte[] b) {
+					mBB.put(b);
+				}
+			    
+			    @Override
+				public void write(final byte[] b, final int off, final int l) {
+					mBB.put(b, off, l);
+				}
+			}.init(b)));
+			b.flip();
+			ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
+			Assert.assertTrue(irb.equals(rb));
+			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE-100000; k += offset) {
+				Assert.assertTrue(irb.contains((int) k));
+			}
+
+			for (int k = Integer.MAX_VALUE - 100000; k < Integer.MAX_VALUE - 100000 +runlength; ++k)
+				Assert.assertTrue(irb.contains(k));
+
+			array = irb.toArray();
+			for(int k = 0; k < array.length - 1; ++k) {
+				Assert.assertTrue((0xFFFFFFFFL & array[k]) <= (0xFFFFFFFFL & array[k + 1]));
+			}
+			//Assert.assertEquals(Integer.MAX_VALUE - 100000 +runlength-1, array[array.length-1]);
+		}
+	}
+
+
+    @Test
+    public void testSerializeImmutable() throws IOException {
+        MutableRoaringBitmap mr = new MutableRoaringBitmap();
+        mr.add(5);
+        ByteBuffer buffer = serializeRoaring(mr);
+        
+        buffer.rewind();
+        buffer = serializeRoaring(new ImmutableRoaringBitmap(buffer));
+
+        buffer.rewind();
+        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+        Assert.assertTrue(ir.contains(5));
+    }
+
+
+
+    @Test
+    public void testSerializeImmutableA() throws IOException {
+        // includes a runcontainer
+        MutableRoaringBitmap mr = new MutableRoaringBitmap();
+        for (int i=1024*1024-20; i < 1024*1024+20; ++i)
+            mr.add(i);
+        mr.runOptimize();
+        
+        ByteBuffer buffer = serializeRoaring(mr);
+        
+        buffer.rewind();
+        buffer = serializeRoaring(new ImmutableRoaringBitmap(buffer));
+
+        buffer.rewind();
+        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+        Assert.assertFalse(ir.contains(5));
+
+        for (int i=1024*1024-20; i < 1024*1024+20; ++i)
+            Assert.assertTrue(ir.contains(i));
+    }
+
+
+
+    @SuppressWarnings("resource")
+	@Test
+    public void testProperSerialization() throws IOException {
+        final int SIZE = 500;
+        final Random rand = new Random(0);
+        for (int i = 0; i < SIZE; ++i) {
+            MutableRoaringBitmap r = new MutableRoaringBitmap();
+            for (int k = 0; k < 500000; ++k) {
+                if (rand.nextDouble() < .5) {
+                    r.add(k);
+                }
+            }
+            ByteBuffer b = ByteBuffer.allocate(r.serializedSizeInBytes());
+            r.serialize(new DataOutputStream(new OutputStream() {
+                ByteBuffer mBB;
+
+                OutputStream init(final ByteBuffer mbb) {
+                    mBB = mbb;
+                    return this;
+                }
+
+                @Override
+                public void close() {
+                }
+
+                @Override
+                public void flush() {
+                }
+                
+                @Override
+                public void write(final int b) {
+                    mBB.put((byte) b);
+                }
+                
+                @Override
+                public void write(final byte[] b) {
+                    mBB.put(b);
+                }
+                
+                @Override
+                public void write(final byte[] b, final int off, final int l) {
+                    mBB.put(b, off, l);
+                }
+            }.init(b)));
+            b.flip();
+            ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
+            Assert.assertTrue(irb.equals(r));
+            Assert.assertTrue(irb.hashCode() == r.hashCode());
+            Assert.assertTrue(irb.getCardinality() == r.getCardinality());
         }
+    }
 
-        @Override
-        public void close() {
+
+    @SuppressWarnings("resource")
+	@Test
+    public void testProperSerializationA() throws IOException {
+        // denser, so we should have run containers
+        final int SIZE = 500;
+        final Random rand = new Random(0);
+        for (int i = 0; i < SIZE; ++i) {
+            MutableRoaringBitmap r = new MutableRoaringBitmap();
+            for (int k = 0; k < 500000; ++k) {
+                if (rand.nextDouble() < .9) {
+                    r.add(k);
+                }
+            }
+            r.runOptimize();
+            ByteBuffer b = ByteBuffer.allocate(r.serializedSizeInBytes());
+            r.serialize(new DataOutputStream(new OutputStream() {
+                ByteBuffer mBB;
+
+                OutputStream init(final ByteBuffer mbb) {
+                    mBB = mbb;
+                    return this;
+                }
+                
+                @Override
+                public void close() {
+                }
+                
+                @Override
+                public void flush() {
+                }
+
+                @Override
+                public void write(final int b) {
+                    mBB.put((byte) b);
+                }
+
+                @Override
+                public void write(final byte[] b) {
+                    mBB.put(b);
+                }
+
+                @Override
+                public void write(final byte[] b, final int off, final int l) {
+                    mBB.put(b, off, l);
+                }
+            }.init(b)));
+            b.flip();
+            ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
+            Assert.assertTrue(irb.hashCode() == r.hashCode());
+            Assert.assertTrue(irb.getCardinality() == r.getCardinality());
         }
+    }
 
-        @Override
-        public void flush() {
+
+	
+    @Test
+    public void testContains() throws IOException {
+        System.out.println("test contains");
+        MutableRoaringBitmap mr = new MutableRoaringBitmap();
+        for(int k = 0; k<1000;++k) {
+            mr.add(17*k);
         }
-
-        @Override
-        public void write(final int b) {
-          mBB.put((byte) b);
+        ByteBuffer buffer = serializeRoaring(mr);
+        buffer.rewind();
+        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+        for(int k = 0; k<17*1000;++k) {
+            Assert.assertTrue(ir.contains(k) == (k/17*17==k));
         }
+    }
+    
 
-        @Override
-        public void write(final byte[] b) {
-          mBB.put(b);
+    @Test
+    public void testContainsA() throws IOException {
+        System.out.println("test contains (runs too)");
+        MutableRoaringBitmap mr = new MutableRoaringBitmap();
+        for(int k = 0; k<1000;++k) {
+            mr.add(17*k);
         }
+        for (int k = 200000; k < 210000; ++k)
+            if (k % 19 != 0)
+                mr.add(k);
+        mr.runOptimize();
 
-        @Override
-        public void write(final byte[] b, final int off, final int l) {
-          mBB.put(b, off, l);
+        ByteBuffer buffer = serializeRoaring(mr);
+        buffer.rewind();
+        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+        for(int k = 0; k<17*1000;++k) {
+            Assert.assertTrue(ir.contains(k) == (k/17*17==k));
         }
-      }.init(b)));
-      b.flip();
-      ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
-      Assert.assertTrue(irb.equals(rb));
-      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
-        Assert.assertTrue(irb.contains((int) k));
-      }
-      Assert.assertTrue(Arrays.equals(array, irb.toArray()));
     }
-  }
+    
 
-  @SuppressWarnings("resource")
-  @Test
-  public void testHighBitsA() throws IOException {
-    // includes some run containers
-    for (int offset = 1 << 14; offset < 1 << 18; offset *= 2) {
-      MutableRoaringBitmap rb = new MutableRoaringBitmap();
-      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE - 100000; k += offset) {
-        rb.add((int) k);
-      }
-      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE - 100000; k += offset) {
-        Assert.assertTrue(rb.contains((int) k));
-      }
 
-      int runlength = 99000;
-      for (int k = Integer.MAX_VALUE - 100000; k < Integer.MAX_VALUE - 100000 + runlength; ++k)
-        rb.add(k);
+    @SuppressWarnings("resource")
+	static ByteBuffer serializeRoaring(ImmutableRoaringBitmap mrb) throws IOException {
+        byte[] backingArray = new byte[mrb.serializedSizeInBytes()+1024];
+			ByteBuffer outbb = ByteBuffer.wrap(backingArray, 1024, mrb.serializedSizeInBytes()).slice();
+			DataOutputStream dos = new DataOutputStream(new OutputStream(){
+	        ByteBuffer mBB;
+	        OutputStream init(ByteBuffer mbb) {mBB=mbb; return this;}
+	            @Override
+	            public void write(int b) {mBB.put((byte) b);}
+	            @Override
+	            public void write(byte[] b) {}
+	            @Override
+	            public void write(byte[] b, int off, int l) { mBB.put(b,off,l); }
+	        }.init(outbb));
+			mrb.serialize(dos);
+			dos.close();
+			
 
-      rb.runOptimize();
+			return outbb;
+	}
 
-      int[] array = rb.toArray();
-      //int pos = 0;
-      // check that it is in sorted order according to unsigned order
-      for (int k = 0; k < array.length - 1; ++k) {
-        Assert.assertTrue((0xFFFFFFFFL & array[k]) <= (0xFFFFFFFFL & array[k + 1]));
-      }
-      ///////////////////////
-      // It was decided that Roaring would consider ints as unsigned
-      ///////////////////////
-      //for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE-100000; k += offset) {
-      //	Assert.assertTrue(array[pos++] == (int)k);
-      //}
-      //Assert.assertTrue(pos+runlength == array.length);
-      ByteBuffer b = ByteBuffer.allocate(rb.serializedSizeInBytes());
-      rb.serialize(new DataOutputStream(new OutputStream() {
-        ByteBuffer mBB;
 
-        OutputStream init(final ByteBuffer mbb) {
-          mBB = mbb;
-          return this;
+
+	@Test
+	public void testHash() {
+		MutableRoaringBitmap rbm1 = new MutableRoaringBitmap();
+		rbm1.add(17);
+		MutableRoaringBitmap rbm2 = new MutableRoaringBitmap();
+		rbm2.add(17);
+		Assert.assertTrue(rbm1.hashCode() == rbm2.hashCode());
+		rbm2 = rbm1.clone();
+		Assert.assertTrue(rbm1.hashCode() == rbm2.hashCode());
+	}
+	
+    @Test
+    public void ANDNOTtest() {
+        final MutableRoaringBitmap rr = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k)
+            rr.add(k);
+        for (int k = 65536; k < 65536 + 4000; ++k)
+            rr.add(k);
+        for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
+            rr.add(k);
+        for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
+            rr.add(k);
+        for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
+            rr.add(k);
+        for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
+            rr.add(k);
+        for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
+            rr.add(k);
+
+        final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void close() {
+        for (int k = 65536; k < 65536 + 4000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void flush() {
+        for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void write(final int b) {
-          mBB.put((byte) b);
+        for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void write(final byte[] b) {
-          mBB.put(b);
+        for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void write(final byte[] b, final int off, final int l) {
-          mBB.put(b, off, l);
+        for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
+            rr2.add(k);
         }
-      }.init(b)));
-      b.flip();
-      ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
-      Assert.assertTrue(irb.equals(rb));
-      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE - 100000; k += offset) {
-        Assert.assertTrue(irb.contains((int) k));
-      }
+        final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
+        rr.andNot(rr2);
+        Assert.assertTrue(correct.equals(rr));
+        Assert.assertTrue(correct.hashCode() == rr.hashCode());
 
-      for (int k = Integer.MAX_VALUE - 100000; k < Integer.MAX_VALUE - 100000 + runlength; ++k)
-        Assert.assertTrue(irb.contains(k));
-
-      array = irb.toArray();
-      for (int k = 0; k < array.length - 1; ++k) {
-        Assert.assertTrue((0xFFFFFFFFL & array[k]) <= (0xFFFFFFFFL & array[k + 1]));
-      }
-      //Assert.assertEquals(Integer.MAX_VALUE - 100000 +runlength-1, array[array.length-1]);
     }
-  }
 
-  @Test
-  public void testSerializeImmutable() throws IOException {
-    MutableRoaringBitmap mr = new MutableRoaringBitmap();
-    mr.add(5);
-    ByteBuffer buffer = serializeRoaring(mr);
 
-    buffer.rewind();
-    buffer = serializeRoaring(new ImmutableRoaringBitmap(buffer));
+    @Test
+    public void ANDNOTtestA() {
+        // both have run containers
+        final MutableRoaringBitmap rr = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k)
+            rr.add(k);
+        for (int k = 65536; k < 65536 + 4000; ++k)
+            rr.add(k);
+        for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
+            rr.add(k);
+        for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
+            rr.add(k);
+        for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
+            rr.add(k);
+        for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
+            rr.add(k);
+        for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
+            rr.add(k);
 
-    buffer.rewind();
-    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-    Assert.assertTrue(ir.contains(5));
-  }
+        rr.runOptimize();
 
-  @Test
-  public void testSerializeImmutableA() throws IOException {
-    // includes a runcontainer
-    MutableRoaringBitmap mr = new MutableRoaringBitmap();
-    for (int i = 1024 * 1024 - 20; i < 1024 * 1024 + 20; ++i)
-      mr.add(i);
-    mr.runOptimize();
-
-    ByteBuffer buffer = serializeRoaring(mr);
-
-    buffer.rewind();
-    buffer = serializeRoaring(new ImmutableRoaringBitmap(buffer));
-
-    buffer.rewind();
-    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-    Assert.assertFalse(ir.contains(5));
-
-    for (int i = 1024 * 1024 - 20; i < 1024 * 1024 + 20; ++i)
-      Assert.assertTrue(ir.contains(i));
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  public void testProperSerialization() throws IOException {
-    final int SIZE = 500;
-    final Random rand = new Random(0);
-    for (int i = 0; i < SIZE; ++i) {
-      MutableRoaringBitmap r = new MutableRoaringBitmap();
-      for (int k = 0; k < 500000; ++k) {
-        if (rand.nextDouble() < .5) {
-          r.add(k);
+        final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k) {
+            rr2.add(k);
         }
-      }
-      ByteBuffer b = ByteBuffer.allocate(r.serializedSizeInBytes());
-      r.serialize(new DataOutputStream(new OutputStream() {
-        ByteBuffer mBB;
-
-        OutputStream init(final ByteBuffer mbb) {
-          mBB = mbb;
-          return this;
+        for (int k = 65536; k < 65536 + 4000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void close() {
+        for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void flush() {
+        for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void write(final int b) {
-          mBB.put((byte) b);
+        for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void write(final byte[] b) {
-          mBB.put(b);
+        for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
+            rr2.add(k);
         }
+        rr2.runOptimize();
+        final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
+        rr.andNot(rr2);
+        Assert.assertTrue(correct.equals(rr));
+        Assert.assertTrue(correct.hashCode() == rr.hashCode());
 
-        @Override
-        public void write(final byte[] b, final int off, final int l) {
-          mBB.put(b, off, l);
+    }
+
+    @Test
+    public void ANDNOTtestB() {
+        // first one has run containers but not second.
+        final MutableRoaringBitmap rr = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k)
+            rr.add(k);
+        for (int k = 65536; k < 65536 + 4000; ++k)
+            rr.add(k);
+        for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
+            rr.add(k);
+        for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
+            rr.add(k);
+        for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
+            rr.add(k);
+        for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
+            rr.add(k);
+        for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
+            rr.add(k);
+
+        rr.runOptimize();
+
+        final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k) {
+            rr2.add(k);
         }
-      }.init(b)));
-      b.flip();
-      ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
-      Assert.assertTrue(irb.equals(r));
-      Assert.assertTrue(irb.hashCode() == r.hashCode());
-      Assert.assertTrue(irb.getCardinality() == r.getCardinality());
-    }
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  public void testProperSerializationA() throws IOException {
-    // denser, so we should have run containers
-    final int SIZE = 500;
-    final Random rand = new Random(0);
-    for (int i = 0; i < SIZE; ++i) {
-      MutableRoaringBitmap r = new MutableRoaringBitmap();
-      for (int k = 0; k < 500000; ++k) {
-        if (rand.nextDouble() < .9) {
-          r.add(k);
+        for (int k = 65536; k < 65536 + 4000; ++k) {
+            rr2.add(k);
         }
-      }
-      r.runOptimize();
-      ByteBuffer b = ByteBuffer.allocate(r.serializedSizeInBytes());
-      r.serialize(new DataOutputStream(new OutputStream() {
-        ByteBuffer mBB;
-
-        OutputStream init(final ByteBuffer mbb) {
-          mBB = mbb;
-          return this;
+        for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void close() {
+        for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void flush() {
+        for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void write(final int b) {
-          mBB.put((byte) b);
+        for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
+            rr2.add(k);
         }
+        final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
+        rr.andNot(rr2);
+        Assert.assertTrue(correct.equals(rr));
+        Assert.assertTrue(correct.hashCode() == rr.hashCode());
 
-        @Override
-        public void write(final byte[] b) {
-          mBB.put(b);
+    }
+
+
+    @Test
+    public void ANDNOTtestC() {
+        // second has run containers, but not first
+        final MutableRoaringBitmap rr = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k)
+            rr.add(k);
+        for (int k = 65536; k < 65536 + 4000; ++k)
+            rr.add(k);
+        for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
+            rr.add(k);
+        for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
+            rr.add(k);
+        for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
+            rr.add(k);
+        for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
+            rr.add(k);
+        for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
+            rr.add(k);
+
+        final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k) {
+            rr2.add(k);
         }
-
-        @Override
-        public void write(final byte[] b, final int off, final int l) {
-          mBB.put(b, off, l);
+        for (int k = 65536; k < 65536 + 4000; ++k) {
+            rr2.add(k);
         }
-      }.init(b)));
-      b.flip();
-      ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
-      Assert.assertTrue(irb.hashCode() == r.hashCode());
-      Assert.assertTrue(irb.getCardinality() == r.getCardinality());
+        for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
+            rr2.add(k);
+        }
+        for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
+            rr2.add(k);
+        }
+        for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
+            rr2.add(k);
+        }
+        for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
+            rr2.add(k);
+        }
+        rr2.runOptimize();
+
+        final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
+        rr.andNot(rr2);
+        Assert.assertTrue(correct.equals(rr));
+        Assert.assertTrue(correct.hashCode() == rr.hashCode());
     }
-  }
 
-  @Test
-  public void testContains() throws IOException {
-    System.out.println("test contains");
-    MutableRoaringBitmap mr = new MutableRoaringBitmap();
-    for (int k = 0; k < 1000; ++k) {
-      mr.add(17 * k);
+
+
+
+
+    
+    @Test
+    public void MappeableContainersAccessTest() throws IOException {
+        MutableRoaringBitmap mr = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k)
+            mr.add(k);
+        for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
+            mr.add(k);
+        for (int k = (1 << 18); k < (1 << 18) + 9000; ++k)
+            mr.add(k);
+        for (int k = (1 << 19); k < (1 << 19) + 7000; ++k)
+            mr.add(k);
+        for (int k = (1 << 20); k < (1 << 20) + 10000; ++k)
+            mr.add(k);
+        for (int k = (1 << 23); k < (1 << 23) + 1000; ++k)
+            mr.add(k);
+        for (int k = (1 << 24); k < (1 << 24) + 30000; ++k)
+            mr.add(k);
+        ByteBuffer buffer = serializeRoaring(mr);
+        buffer.rewind();
+        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+        mr = ir.toMutableRoaringBitmap();
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableArrayContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableArrayContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableBitmapContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableBitmapContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableBitmapContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableArrayContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(6)) instanceof MappeableBitmapContainer);
+        
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality()==256);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality()==4000);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality()==9000);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality()==7000);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality()==10000);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality()==1000);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(6).getCardinality()==30000);
+        
+        MutableRoaringBitmap mr2 = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k)
+            mr2.add(k);
+        for (int k = (1 << 16); k < (1 << 16) + 4000; ++k) 
+            mr2.add(k);
+        for (int k = (1 << 18) + 2000; k < (1 << 18) + 8000; ++k) 
+            mr2.add(k);
+        for (int k = (1 << 21); k < (1 << 21) + 1000; ++k) 
+            mr2.add(k);
+        for (int k = (1 << 22); k < (1 << 22) + 2000; ++k)
+            mr2.add(k);
+        for (int k = (1 << 25); k < (1 << 25) + 5000; ++k)
+            mr2.add(k);        
+        buffer = serializeRoaring(mr2);
+        buffer.rewind();
+        ImmutableRoaringBitmap ir2 = new ImmutableRoaringBitmap(buffer);
+        mr2 = ir2.toMutableRoaringBitmap();
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableArrayContainer);
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableArrayContainer);
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableBitmapContainer);
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableArrayContainer);
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableArrayContainer);
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableBitmapContainer);
+        
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality()==256);
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality()==4000);
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality()==6000);
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality()==1000);
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality()==2000);
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality()==5000);
+        
+        MutableRoaringBitmap mr3 = new MutableRoaringBitmap();
+        buffer = serializeRoaring(mr3);
+        buffer.rewind();
+        ImmutableRoaringBitmap ir3 = new ImmutableRoaringBitmap(buffer);
+        mr3 = ir3.toMutableRoaringBitmap();
+        
+        Assert.assertTrue(mr3.getCardinality()==0);
     }
-    ByteBuffer buffer = serializeRoaring(mr);
-    buffer.rewind();
-    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-    for (int k = 0; k < 17 * 1000; ++k) {
-      Assert.assertTrue(ir.contains(k) == (k / 17 * 17 == k));
+
+ @Test
+    public void MappeableContainersAccessTestA() throws IOException {
+     // run containers too
+        MutableRoaringBitmap mr = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k)
+            mr.add(k);
+        for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
+            mr.add(k);
+        for (int k = (1 << 18); k < (1 << 18) + 9000; ++k)
+            mr.add(k);
+        for (int k = (1 << 19); k < (1 << 19) + 7000; ++k)
+            mr.add(k);
+        for (int k = (1 << 20); k < (1 << 20) + 10000; ++k)
+            mr.add(k);
+        for (int k = (1 << 23); k < (1 << 23) + 1000; ++k)
+            mr.add(k);
+        for (int k = (1 << 24); k < (1 << 24) + 30000; ++k)
+            mr.add(k);
+        mr.runOptimize();
+        ByteBuffer buffer = serializeRoaring(mr);
+        buffer.rewind();
+        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+        mr = ir.toMutableRoaringBitmap();
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(6)) instanceof MappeableRunContainer);
+        
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality()==256);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality()==4000);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality()==9000);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality()==7000);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality()==10000);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality()==1000);
+        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(6).getCardinality()==30000);
+        
+        MutableRoaringBitmap mr2 = new MutableRoaringBitmap();
+        for (int k = 4000; k < 4256; ++k)
+            mr2.add(k);
+        for (int k = (1 << 16); k < (1 << 16) + 4000; ++k) 
+            mr2.add(k);
+        for (int k = (1 << 18) + 2000; k < (1 << 18) + 8000; ++k) 
+            mr2.add(k);
+        for (int k = (1 << 21); k < (1 << 21) + 1000; ++k) 
+            mr2.add(k);
+        for (int k = (1 << 22); k < (1 << 22) + 2000; ++k)
+            mr2.add(k);
+        for (int k = (1 << 25); k < (1 << 25) + 5000; ++k)
+            mr2.add(k);        
+        mr2.runOptimize();
+        buffer = serializeRoaring(mr2);
+        buffer.rewind();
+        ImmutableRoaringBitmap ir2 = new ImmutableRoaringBitmap(buffer);
+        mr2 = ir2.toMutableRoaringBitmap();
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableRunContainer);
+        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableRunContainer);
+        
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality()==256);
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality()==4000);
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality()==6000);
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality()==1000);
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality()==2000);
+        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality()==5000);
+        
+        MutableRoaringBitmap mr3 = new MutableRoaringBitmap();
+        buffer = serializeRoaring(mr3);
+        buffer.rewind();
+        ImmutableRoaringBitmap ir3 = new ImmutableRoaringBitmap(buffer);
+        mr3 = ir3.toMutableRoaringBitmap();
+        
+        Assert.assertTrue(mr3.getCardinality()==0);
     }
-  }
 
-  @Test
-  public void testContainsA() throws IOException {
-    System.out.println("test contains (runs too)");
-    MutableRoaringBitmap mr = new MutableRoaringBitmap();
-    for (int k = 0; k < 1000; ++k) {
-      mr.add(17 * k);
+
+
+
+
+
+    @Test
+    public void andnottest4() {
+        final MutableRoaringBitmap rb = new MutableRoaringBitmap();
+        final MutableRoaringBitmap rb2 = new MutableRoaringBitmap();
+
+        for (int i = 0; i < 200000; i += 4)
+            rb2.add(i);
+        for (int i = 200000; i < 400000; i += 14)
+            rb2.add(i);
+        rb2.getCardinality();
+
+        // check op against an empty bitmap
+        final MutableRoaringBitmap andNotresult = MutableRoaringBitmap
+                .andNot(rb, rb2);
+        final MutableRoaringBitmap off = MutableRoaringBitmap.andNot(rb2, rb);
+
+        Assert.assertEquals(rb, andNotresult);
+        Assert.assertEquals(rb2, off);
+        rb2.andNot(rb);
+        Assert.assertEquals(rb2, off);
     }
-    for (int k = 200000; k < 210000; ++k)
-      if (k % 19 != 0)
-        mr.add(k);
-    mr.runOptimize();
 
-    ByteBuffer buffer = serializeRoaring(mr);
-    buffer.rewind();
-    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-    for (int k = 0; k < 17 * 1000; ++k) {
-      Assert.assertTrue(ir.contains(k) == (k / 17 * 17 == k));
+@Test
+    public void andnottest4A() {
+        final MutableRoaringBitmap rb = new MutableRoaringBitmap();
+        final MutableRoaringBitmap rb2 = new MutableRoaringBitmap();
+
+        for (int i = 0; i < 200000; i++)
+            if (i % 9 < 6) 
+                rb2.add(i);
+        for (int i = 200000; i < 400000; i += 14)
+            rb2.add(i);
+        rb2.getCardinality();
+        rb2.runOptimize();
+
+        // check against an empty bitmap
+        final MutableRoaringBitmap andNotresult = MutableRoaringBitmap
+                .andNot(rb, rb2);
+        final MutableRoaringBitmap off = MutableRoaringBitmap.andNot(rb2, rb);
+
+        Assert.assertEquals(rb, andNotresult);
+        Assert.assertEquals(rb2, off);
+        rb2.andNot(rb);
+        Assert.assertEquals(rb2, off);
     }
-  }
-
-  @SuppressWarnings("resource")
-  static ByteBuffer serializeRoaring(ImmutableRoaringBitmap mrb) throws IOException {
-    byte[] backingArray = new byte[mrb.serializedSizeInBytes() + 1024];
-    ByteBuffer outbb = ByteBuffer.wrap(backingArray, 1024, mrb.serializedSizeInBytes()).slice();
-    DataOutputStream dos = new DataOutputStream(new OutputStream() {
-      ByteBuffer mBB;
-
-      OutputStream init(ByteBuffer mbb) {
-        mBB = mbb;
-        return this;
-      }
-
-      @Override
-      public void write(int b) {
-        mBB.put((byte) b);
-      }
-
-      @Override
-      public void write(byte[] b) {
-      }
-
-      @Override
-      public void write(byte[] b, int off, int l) {
-        mBB.put(b, off, l);
-      }
-    }.init(outbb));
-    mrb.serialize(dos);
-    dos.close();
-
-    return outbb;
-  }
-
-  @Test
-  public void testHash() {
-    MutableRoaringBitmap rbm1 = new MutableRoaringBitmap();
-    rbm1.add(17);
-    MutableRoaringBitmap rbm2 = new MutableRoaringBitmap();
-    rbm2.add(17);
-    Assert.assertTrue(rbm1.hashCode() == rbm2.hashCode());
-    rbm2 = rbm1.clone();
-    Assert.assertTrue(rbm1.hashCode() == rbm2.hashCode());
-  }
-
-  @Test
-  public void ANDNOTtest() {
-    final MutableRoaringBitmap rr = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k)
-      rr.add(k);
-    for (int k = 65536; k < 65536 + 4000; ++k)
-      rr.add(k);
-    for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
-      rr.add(k);
-    for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
-      rr.add(k);
-    for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
-      rr.add(k);
-    for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
-      rr.add(k);
-    for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
-      rr.add(k);
-
-    final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 65536; k < 65536 + 4000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
-      rr2.add(k);
-    }
-    final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
-    rr.andNot(rr2);
-    Assert.assertTrue(correct.equals(rr));
-    Assert.assertTrue(correct.hashCode() == rr.hashCode());
-
-  }
-
-  @Test
-  public void ANDNOTtestA() {
-    // both have run containers
-    final MutableRoaringBitmap rr = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k)
-      rr.add(k);
-    for (int k = 65536; k < 65536 + 4000; ++k)
-      rr.add(k);
-    for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
-      rr.add(k);
-    for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
-      rr.add(k);
-    for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
-      rr.add(k);
-    for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
-      rr.add(k);
-    for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
-      rr.add(k);
-
-    rr.runOptimize();
-
-    final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 65536; k < 65536 + 4000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
-      rr2.add(k);
-    }
-    rr2.runOptimize();
-    final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
-    rr.andNot(rr2);
-    Assert.assertTrue(correct.equals(rr));
-    Assert.assertTrue(correct.hashCode() == rr.hashCode());
-
-  }
-
-  @Test
-  public void ANDNOTtestB() {
-    // first one has run containers but not second.
-    final MutableRoaringBitmap rr = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k)
-      rr.add(k);
-    for (int k = 65536; k < 65536 + 4000; ++k)
-      rr.add(k);
-    for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
-      rr.add(k);
-    for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
-      rr.add(k);
-    for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
-      rr.add(k);
-    for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
-      rr.add(k);
-    for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
-      rr.add(k);
-
-    rr.runOptimize();
-
-    final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 65536; k < 65536 + 4000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
-      rr2.add(k);
-    }
-    final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
-    rr.andNot(rr2);
-    Assert.assertTrue(correct.equals(rr));
-    Assert.assertTrue(correct.hashCode() == rr.hashCode());
-
-  }
-
-  @Test
-  public void ANDNOTtestC() {
-    // second has run containers, but not first
-    final MutableRoaringBitmap rr = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k)
-      rr.add(k);
-    for (int k = 65536; k < 65536 + 4000; ++k)
-      rr.add(k);
-    for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
-      rr.add(k);
-    for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
-      rr.add(k);
-    for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
-      rr.add(k);
-    for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
-      rr.add(k);
-    for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
-      rr.add(k);
-
-    final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 65536; k < 65536 + 4000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
-      rr2.add(k);
-    }
-    for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
-      rr2.add(k);
-    }
-    rr2.runOptimize();
-
-    final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
-    rr.andNot(rr2);
-    Assert.assertTrue(correct.equals(rr));
-    Assert.assertTrue(correct.hashCode() == rr.hashCode());
-  }
-
-  @Test
-  public void MappeableContainersAccessTest() throws IOException {
-    MutableRoaringBitmap mr = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k)
-      mr.add(k);
-    for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
-      mr.add(k);
-    for (int k = (1 << 18); k < (1 << 18) + 9000; ++k)
-      mr.add(k);
-    for (int k = (1 << 19); k < (1 << 19) + 7000; ++k)
-      mr.add(k);
-    for (int k = (1 << 20); k < (1 << 20) + 10000; ++k)
-      mr.add(k);
-    for (int k = (1 << 23); k < (1 << 23) + 1000; ++k)
-      mr.add(k);
-    for (int k = (1 << 24); k < (1 << 24) + 30000; ++k)
-      mr.add(k);
-    ByteBuffer buffer = serializeRoaring(mr);
-    buffer.rewind();
-    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-    mr = ir.toMutableRoaringBitmap();
-    Assert
-        .assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableArrayContainer);
-    Assert
-        .assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableArrayContainer);
-    Assert.assertTrue(
-        (Object) (mr.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableBitmapContainer);
-    Assert.assertTrue(
-        (Object) (mr.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableBitmapContainer);
-    Assert.assertTrue(
-        (Object) (mr.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableBitmapContainer);
-    Assert
-        .assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableArrayContainer);
-    Assert.assertTrue(
-        (Object) (mr.getMappeableRoaringArray().getContainerAtIndex(6)) instanceof MappeableBitmapContainer);
-
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality() == 256);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality() == 4000);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality() == 9000);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality() == 7000);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality() == 10000);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality() == 1000);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(6).getCardinality() == 30000);
-
-    MutableRoaringBitmap mr2 = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k)
-      mr2.add(k);
-    for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
-      mr2.add(k);
-    for (int k = (1 << 18) + 2000; k < (1 << 18) + 8000; ++k)
-      mr2.add(k);
-    for (int k = (1 << 21); k < (1 << 21) + 1000; ++k)
-      mr2.add(k);
-    for (int k = (1 << 22); k < (1 << 22) + 2000; ++k)
-      mr2.add(k);
-    for (int k = (1 << 25); k < (1 << 25) + 5000; ++k)
-      mr2.add(k);
-    buffer = serializeRoaring(mr2);
-    buffer.rewind();
-    ImmutableRoaringBitmap ir2 = new ImmutableRoaringBitmap(buffer);
-    mr2 = ir2.toMutableRoaringBitmap();
-    Assert.assertTrue(
-        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableArrayContainer);
-    Assert.assertTrue(
-        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableArrayContainer);
-    Assert.assertTrue(
-        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableBitmapContainer);
-    Assert.assertTrue(
-        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableArrayContainer);
-    Assert.assertTrue(
-        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableArrayContainer);
-    Assert.assertTrue(
-        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableBitmapContainer);
-
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality() == 256);
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality() == 4000);
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality() == 6000);
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality() == 1000);
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality() == 2000);
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality() == 5000);
-
-    MutableRoaringBitmap mr3 = new MutableRoaringBitmap();
-    buffer = serializeRoaring(mr3);
-    buffer.rewind();
-    ImmutableRoaringBitmap ir3 = new ImmutableRoaringBitmap(buffer);
-    mr3 = ir3.toMutableRoaringBitmap();
-
-    Assert.assertTrue(mr3.getCardinality() == 0);
-  }
-
-  @Test
-  public void MappeableContainersAccessTestA() throws IOException {
-    // run containers too
-    MutableRoaringBitmap mr = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k)
-      mr.add(k);
-    for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
-      mr.add(k);
-    for (int k = (1 << 18); k < (1 << 18) + 9000; ++k)
-      mr.add(k);
-    for (int k = (1 << 19); k < (1 << 19) + 7000; ++k)
-      mr.add(k);
-    for (int k = (1 << 20); k < (1 << 20) + 10000; ++k)
-      mr.add(k);
-    for (int k = (1 << 23); k < (1 << 23) + 1000; ++k)
-      mr.add(k);
-    for (int k = (1 << 24); k < (1 << 24) + 30000; ++k)
-      mr.add(k);
-    mr.runOptimize();
-    ByteBuffer buffer = serializeRoaring(mr);
-    buffer.rewind();
-    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-    mr = ir.toMutableRoaringBitmap();
-    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableRunContainer);
-    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableRunContainer);
-    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableRunContainer);
-    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableRunContainer);
-    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableRunContainer);
-    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableRunContainer);
-    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(6)) instanceof MappeableRunContainer);
-
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality() == 256);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality() == 4000);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality() == 9000);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality() == 7000);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality() == 10000);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality() == 1000);
-    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(6).getCardinality() == 30000);
-
-    MutableRoaringBitmap mr2 = new MutableRoaringBitmap();
-    for (int k = 4000; k < 4256; ++k)
-      mr2.add(k);
-    for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
-      mr2.add(k);
-    for (int k = (1 << 18) + 2000; k < (1 << 18) + 8000; ++k)
-      mr2.add(k);
-    for (int k = (1 << 21); k < (1 << 21) + 1000; ++k)
-      mr2.add(k);
-    for (int k = (1 << 22); k < (1 << 22) + 2000; ++k)
-      mr2.add(k);
-    for (int k = (1 << 25); k < (1 << 25) + 5000; ++k)
-      mr2.add(k);
-    mr2.runOptimize();
-    buffer = serializeRoaring(mr2);
-    buffer.rewind();
-    ImmutableRoaringBitmap ir2 = new ImmutableRoaringBitmap(buffer);
-    mr2 = ir2.toMutableRoaringBitmap();
-    Assert
-        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableRunContainer);
-    Assert
-        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableRunContainer);
-    Assert
-        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableRunContainer);
-    Assert
-        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableRunContainer);
-    Assert
-        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableRunContainer);
-    Assert
-        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableRunContainer);
-
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality() == 256);
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality() == 4000);
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality() == 6000);
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality() == 1000);
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality() == 2000);
-    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality() == 5000);
-
-    MutableRoaringBitmap mr3 = new MutableRoaringBitmap();
-    buffer = serializeRoaring(mr3);
-    buffer.rewind();
-    ImmutableRoaringBitmap ir3 = new ImmutableRoaringBitmap(buffer);
-    mr3 = ir3.toMutableRoaringBitmap();
-
-    Assert.assertTrue(mr3.getCardinality() == 0);
-  }
-
-  @Test
-  public void andnottest4() {
-    final MutableRoaringBitmap rb = new MutableRoaringBitmap();
-    final MutableRoaringBitmap rb2 = new MutableRoaringBitmap();
-
-    for (int i = 0; i < 200000; i += 4)
-      rb2.add(i);
-    for (int i = 200000; i < 400000; i += 14)
-      rb2.add(i);
-    rb2.getCardinality();
-
-    // check op against an empty bitmap
-    final MutableRoaringBitmap andNotresult = MutableRoaringBitmap.andNot(rb, rb2);
-    final MutableRoaringBitmap off = MutableRoaringBitmap.andNot(rb2, rb);
-
-    Assert.assertEquals(rb, andNotresult);
-    Assert.assertEquals(rb2, off);
-    rb2.andNot(rb);
-    Assert.assertEquals(rb2, off);
-  }
-
-  @Test
-  public void andnottest4A() {
-    final MutableRoaringBitmap rb = new MutableRoaringBitmap();
-    final MutableRoaringBitmap rb2 = new MutableRoaringBitmap();
-
-    for (int i = 0; i < 200000; i++)
-      if (i % 9 < 6)
-        rb2.add(i);
-    for (int i = 200000; i < 400000; i += 14)
-      rb2.add(i);
-    rb2.getCardinality();
-    rb2.runOptimize();
-
-    // check against an empty bitmap
-    final MutableRoaringBitmap andNotresult = MutableRoaringBitmap.andNot(rb, rb2);
-    final MutableRoaringBitmap off = MutableRoaringBitmap.andNot(rb2, rb);
-
-    Assert.assertEquals(rb, andNotresult);
-    Assert.assertEquals(rb2, off);
-    rb2.andNot(rb);
-    Assert.assertEquals(rb2, off);
-  }
 
   @Test
   public void fliptest1() {
@@ -809,6 +805,7 @@ public class TestImmutableRoaringBitmap {
 
     Assert.assertEquals(result, rb2);
   }
+
 
   @Test
   public void testRangedOr() {
@@ -853,5 +850,4 @@ public class TestImmutableRoaringBitmap {
       Assert.assertEquals(expectedResultSet, actualResultSet);
     }
   }
-
 }

--- a/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
+++ b/src/test/java/org/roaringbitmap/buffer/TestImmutableRoaringBitmap.java
@@ -7,6 +7,7 @@ package org.roaringbitmap.buffer;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.roaringbitmap.IntIterator;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MappeableArrayContainer;
 import org.roaringbitmap.buffer.MappeableBitmapContainer;
@@ -15,768 +16,775 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+
 
 /**
  * Generic testing of the roaring bitmaps
  */
-@SuppressWarnings({"static-method"})
+@SuppressWarnings({ "static-method" })
 public class TestImmutableRoaringBitmap {
-	@Test
-	public void testHighBits() throws IOException {
-		// version without any runcontainers (earlier serialization version)
-		for (int offset = 1 << 14; offset < 1 << 18; offset *= 2) {
-			MutableRoaringBitmap rb = new MutableRoaringBitmap();
-			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
-				rb.add((int) k);
-			}
-			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
-				Assert.assertTrue(rb.contains((int) k));
-			}
-			int[] array = rb.toArray();
-			ByteBuffer b = ByteBuffer.allocate(rb.serializedSizeInBytes());
-			rb.serialize(new DataOutputStream(new OutputStream() {
-				ByteBuffer mBB;
+  @Test
+  public void testHighBits() throws IOException {
+    // version without any runcontainers (earlier serialization version)
+    for (int offset = 1 << 14; offset < 1 << 18; offset *= 2) {
+      MutableRoaringBitmap rb = new MutableRoaringBitmap();
+      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
+        rb.add((int) k);
+      }
+      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
+        Assert.assertTrue(rb.contains((int) k));
+      }
+      int[] array = rb.toArray();
+      ByteBuffer b = ByteBuffer.allocate(rb.serializedSizeInBytes());
+      rb.serialize(new DataOutputStream(new OutputStream() {
+        ByteBuffer mBB;
 
-				OutputStream init(final ByteBuffer mbb) {
-					mBB = mbb;
-					return this;
-				}
-				
-			    @Override
-				public void close() {
-				}
-			    
-			    @Override
-				public void flush() {
-				}
-			    
-			    @Override
-				public void write(final int b) {
-					mBB.put((byte) b);
-				}
-			    
-			    @Override
-				public void write(final byte[] b) {
-					mBB.put(b);
-				}
+        OutputStream init(final ByteBuffer mbb) {
+          mBB = mbb;
+          return this;
+        }
 
-			    @Override
-				public void write(final byte[] b, final int off, final int l) {
-					mBB.put(b, off, l);
-				}
-			}.init(b)));
-			b.flip();
-			ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
-			Assert.assertTrue(irb.equals(rb));
-			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
-				Assert.assertTrue(irb.contains((int) k));
-			}
-			Assert.assertTrue(Arrays.equals(array, irb.toArray()));
-		}
-	}
+        @Override
+        public void close() {
+        }
 
-	@SuppressWarnings("resource")
-	@Test
-	public void testHighBitsA() throws IOException {
-		// includes some run containers
-		for (int offset = 1 << 14; offset < 1 << 18; offset *= 2) {
-			MutableRoaringBitmap rb = new MutableRoaringBitmap();
-			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE - 100000; k += offset) {
-				rb.add((int) k);
-			}
-			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE - 100000; k += offset) {
-				Assert.assertTrue(rb.contains((int) k));
-			}
+        @Override
+        public void flush() {
+        }
 
-			int runlength=99000;
-			for (int k = Integer.MAX_VALUE - 100000; k < Integer.MAX_VALUE - 100000 +runlength; ++k)
-				rb.add(k);
+        @Override
+        public void write(final int b) {
+          mBB.put((byte) b);
+        }
 
-			rb.runOptimize();
+        @Override
+        public void write(final byte[] b) {
+          mBB.put(b);
+        }
 
-			int[] array = rb.toArray();
-			//int pos = 0;
-			// check that it is in sorted order according to unsigned order
-			for(int k = 0; k < array.length - 1; ++k) {
-				Assert.assertTrue((0xFFFFFFFFL & array[k]) <= (0xFFFFFFFFL & array[k + 1]));
-			}
-			///////////////////////
-			// It was decided that Roaring would consider ints as unsigned
-			///////////////////////
-			//for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE-100000; k += offset) {
-			//	Assert.assertTrue(array[pos++] == (int)k);
-			//}
-			//Assert.assertTrue(pos+runlength == array.length);
-			ByteBuffer b = ByteBuffer.allocate(rb.serializedSizeInBytes());
-			rb.serialize(new DataOutputStream(new OutputStream() {
-				ByteBuffer mBB;
-
-				OutputStream init(final ByteBuffer mbb) {
-					mBB = mbb;
-					return this;
-				}
-				
-			    @Override
-				public void close() {
-				}
-
-			    @Override
-				public void flush() {
-				}
-
-			    @Override
-				public void write(final int b) {
-					mBB.put((byte) b);
-				}
-			    
-			    @Override
-				public void write(final byte[] b) {
-					mBB.put(b);
-				}
-			    
-			    @Override
-				public void write(final byte[] b, final int off, final int l) {
-					mBB.put(b, off, l);
-				}
-			}.init(b)));
-			b.flip();
-			ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
-			Assert.assertTrue(irb.equals(rb));
-			for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE-100000; k += offset) {
-				Assert.assertTrue(irb.contains((int) k));
-			}
-
-			for (int k = Integer.MAX_VALUE - 100000; k < Integer.MAX_VALUE - 100000 +runlength; ++k)
-				Assert.assertTrue(irb.contains(k));
-
-			array = irb.toArray();
-			for(int k = 0; k < array.length - 1; ++k) {
-				Assert.assertTrue((0xFFFFFFFFL & array[k]) <= (0xFFFFFFFFL & array[k + 1]));
-			}
-			//Assert.assertEquals(Integer.MAX_VALUE - 100000 +runlength-1, array[array.length-1]);
-		}
-	}
-
-
-    @Test
-    public void testSerializeImmutable() throws IOException {
-        MutableRoaringBitmap mr = new MutableRoaringBitmap();
-        mr.add(5);
-        ByteBuffer buffer = serializeRoaring(mr);
-        
-        buffer.rewind();
-        buffer = serializeRoaring(new ImmutableRoaringBitmap(buffer));
-
-        buffer.rewind();
-        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-        Assert.assertTrue(ir.contains(5));
+        @Override
+        public void write(final byte[] b, final int off, final int l) {
+          mBB.put(b, off, l);
+        }
+      }.init(b)));
+      b.flip();
+      ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
+      Assert.assertTrue(irb.equals(rb));
+      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE; k += offset) {
+        Assert.assertTrue(irb.contains((int) k));
+      }
+      Assert.assertTrue(Arrays.equals(array, irb.toArray()));
     }
+  }
 
+  @SuppressWarnings("resource")
+  @Test
+  public void testHighBitsA() throws IOException {
+    // includes some run containers
+    for (int offset = 1 << 14; offset < 1 << 18; offset *= 2) {
+      MutableRoaringBitmap rb = new MutableRoaringBitmap();
+      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE - 100000; k += offset) {
+        rb.add((int) k);
+      }
+      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE - 100000; k += offset) {
+        Assert.assertTrue(rb.contains((int) k));
+      }
 
+      int runlength = 99000;
+      for (int k = Integer.MAX_VALUE - 100000; k < Integer.MAX_VALUE - 100000 + runlength; ++k)
+        rb.add(k);
 
-    @Test
-    public void testSerializeImmutableA() throws IOException {
-        // includes a runcontainer
-        MutableRoaringBitmap mr = new MutableRoaringBitmap();
-        for (int i=1024*1024-20; i < 1024*1024+20; ++i)
-            mr.add(i);
-        mr.runOptimize();
-        
-        ByteBuffer buffer = serializeRoaring(mr);
-        
-        buffer.rewind();
-        buffer = serializeRoaring(new ImmutableRoaringBitmap(buffer));
+      rb.runOptimize();
 
-        buffer.rewind();
-        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-        Assert.assertFalse(ir.contains(5));
+      int[] array = rb.toArray();
+      //int pos = 0;
+      // check that it is in sorted order according to unsigned order
+      for (int k = 0; k < array.length - 1; ++k) {
+        Assert.assertTrue((0xFFFFFFFFL & array[k]) <= (0xFFFFFFFFL & array[k + 1]));
+      }
+      ///////////////////////
+      // It was decided that Roaring would consider ints as unsigned
+      ///////////////////////
+      //for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE-100000; k += offset) {
+      //	Assert.assertTrue(array[pos++] == (int)k);
+      //}
+      //Assert.assertTrue(pos+runlength == array.length);
+      ByteBuffer b = ByteBuffer.allocate(rb.serializedSizeInBytes());
+      rb.serialize(new DataOutputStream(new OutputStream() {
+        ByteBuffer mBB;
 
-        for (int i=1024*1024-20; i < 1024*1024+20; ++i)
-            Assert.assertTrue(ir.contains(i));
+        OutputStream init(final ByteBuffer mbb) {
+          mBB = mbb;
+          return this;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void write(final int b) {
+          mBB.put((byte) b);
+        }
+
+        @Override
+        public void write(final byte[] b) {
+          mBB.put(b);
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int l) {
+          mBB.put(b, off, l);
+        }
+      }.init(b)));
+      b.flip();
+      ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
+      Assert.assertTrue(irb.equals(rb));
+      for (long k = Integer.MIN_VALUE; k < Integer.MAX_VALUE - 100000; k += offset) {
+        Assert.assertTrue(irb.contains((int) k));
+      }
+
+      for (int k = Integer.MAX_VALUE - 100000; k < Integer.MAX_VALUE - 100000 + runlength; ++k)
+        Assert.assertTrue(irb.contains(k));
+
+      array = irb.toArray();
+      for (int k = 0; k < array.length - 1; ++k) {
+        Assert.assertTrue((0xFFFFFFFFL & array[k]) <= (0xFFFFFFFFL & array[k + 1]));
+      }
+      //Assert.assertEquals(Integer.MAX_VALUE - 100000 +runlength-1, array[array.length-1]);
     }
+  }
 
+  @Test
+  public void testSerializeImmutable() throws IOException {
+    MutableRoaringBitmap mr = new MutableRoaringBitmap();
+    mr.add(5);
+    ByteBuffer buffer = serializeRoaring(mr);
 
+    buffer.rewind();
+    buffer = serializeRoaring(new ImmutableRoaringBitmap(buffer));
 
-    @SuppressWarnings("resource")
-	@Test
-    public void testProperSerialization() throws IOException {
-        final int SIZE = 500;
-        final Random rand = new Random(0);
-        for (int i = 0; i < SIZE; ++i) {
-            MutableRoaringBitmap r = new MutableRoaringBitmap();
-            for (int k = 0; k < 500000; ++k) {
-                if (rand.nextDouble() < .5) {
-                    r.add(k);
-                }
-            }
-            ByteBuffer b = ByteBuffer.allocate(r.serializedSizeInBytes());
-            r.serialize(new DataOutputStream(new OutputStream() {
-                ByteBuffer mBB;
+    buffer.rewind();
+    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+    Assert.assertTrue(ir.contains(5));
+  }
 
-                OutputStream init(final ByteBuffer mbb) {
-                    mBB = mbb;
-                    return this;
-                }
+  @Test
+  public void testSerializeImmutableA() throws IOException {
+    // includes a runcontainer
+    MutableRoaringBitmap mr = new MutableRoaringBitmap();
+    for (int i = 1024 * 1024 - 20; i < 1024 * 1024 + 20; ++i)
+      mr.add(i);
+    mr.runOptimize();
 
-                @Override
-                public void close() {
-                }
+    ByteBuffer buffer = serializeRoaring(mr);
 
-                @Override
-                public void flush() {
-                }
-                
-                @Override
-                public void write(final int b) {
-                    mBB.put((byte) b);
-                }
-                
-                @Override
-                public void write(final byte[] b) {
-                    mBB.put(b);
-                }
-                
-                @Override
-                public void write(final byte[] b, final int off, final int l) {
-                    mBB.put(b, off, l);
-                }
-            }.init(b)));
-            b.flip();
-            ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
-            Assert.assertTrue(irb.equals(r));
-            Assert.assertTrue(irb.hashCode() == r.hashCode());
-            Assert.assertTrue(irb.getCardinality() == r.getCardinality());
+    buffer.rewind();
+    buffer = serializeRoaring(new ImmutableRoaringBitmap(buffer));
+
+    buffer.rewind();
+    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+    Assert.assertFalse(ir.contains(5));
+
+    for (int i = 1024 * 1024 - 20; i < 1024 * 1024 + 20; ++i)
+      Assert.assertTrue(ir.contains(i));
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  public void testProperSerialization() throws IOException {
+    final int SIZE = 500;
+    final Random rand = new Random(0);
+    for (int i = 0; i < SIZE; ++i) {
+      MutableRoaringBitmap r = new MutableRoaringBitmap();
+      for (int k = 0; k < 500000; ++k) {
+        if (rand.nextDouble() < .5) {
+          r.add(k);
         }
+      }
+      ByteBuffer b = ByteBuffer.allocate(r.serializedSizeInBytes());
+      r.serialize(new DataOutputStream(new OutputStream() {
+        ByteBuffer mBB;
+
+        OutputStream init(final ByteBuffer mbb) {
+          mBB = mbb;
+          return this;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void write(final int b) {
+          mBB.put((byte) b);
+        }
+
+        @Override
+        public void write(final byte[] b) {
+          mBB.put(b);
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int l) {
+          mBB.put(b, off, l);
+        }
+      }.init(b)));
+      b.flip();
+      ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
+      Assert.assertTrue(irb.equals(r));
+      Assert.assertTrue(irb.hashCode() == r.hashCode());
+      Assert.assertTrue(irb.getCardinality() == r.getCardinality());
     }
+  }
 
-
-    @SuppressWarnings("resource")
-	@Test
-    public void testProperSerializationA() throws IOException {
-        // denser, so we should have run containers
-        final int SIZE = 500;
-        final Random rand = new Random(0);
-        for (int i = 0; i < SIZE; ++i) {
-            MutableRoaringBitmap r = new MutableRoaringBitmap();
-            for (int k = 0; k < 500000; ++k) {
-                if (rand.nextDouble() < .9) {
-                    r.add(k);
-                }
-            }
-            r.runOptimize();
-            ByteBuffer b = ByteBuffer.allocate(r.serializedSizeInBytes());
-            r.serialize(new DataOutputStream(new OutputStream() {
-                ByteBuffer mBB;
-
-                OutputStream init(final ByteBuffer mbb) {
-                    mBB = mbb;
-                    return this;
-                }
-                
-                @Override
-                public void close() {
-                }
-                
-                @Override
-                public void flush() {
-                }
-
-                @Override
-                public void write(final int b) {
-                    mBB.put((byte) b);
-                }
-
-                @Override
-                public void write(final byte[] b) {
-                    mBB.put(b);
-                }
-
-                @Override
-                public void write(final byte[] b, final int off, final int l) {
-                    mBB.put(b, off, l);
-                }
-            }.init(b)));
-            b.flip();
-            ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
-            Assert.assertTrue(irb.hashCode() == r.hashCode());
-            Assert.assertTrue(irb.getCardinality() == r.getCardinality());
+  @SuppressWarnings("resource")
+  @Test
+  public void testProperSerializationA() throws IOException {
+    // denser, so we should have run containers
+    final int SIZE = 500;
+    final Random rand = new Random(0);
+    for (int i = 0; i < SIZE; ++i) {
+      MutableRoaringBitmap r = new MutableRoaringBitmap();
+      for (int k = 0; k < 500000; ++k) {
+        if (rand.nextDouble() < .9) {
+          r.add(k);
         }
+      }
+      r.runOptimize();
+      ByteBuffer b = ByteBuffer.allocate(r.serializedSizeInBytes());
+      r.serialize(new DataOutputStream(new OutputStream() {
+        ByteBuffer mBB;
+
+        OutputStream init(final ByteBuffer mbb) {
+          mBB = mbb;
+          return this;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void write(final int b) {
+          mBB.put((byte) b);
+        }
+
+        @Override
+        public void write(final byte[] b) {
+          mBB.put(b);
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int l) {
+          mBB.put(b, off, l);
+        }
+      }.init(b)));
+      b.flip();
+      ImmutableRoaringBitmap irb = new ImmutableRoaringBitmap(b);
+      Assert.assertTrue(irb.hashCode() == r.hashCode());
+      Assert.assertTrue(irb.getCardinality() == r.getCardinality());
     }
+  }
 
-
-	
-    @Test
-    public void testContains() throws IOException {
-        System.out.println("test contains");
-        MutableRoaringBitmap mr = new MutableRoaringBitmap();
-        for(int k = 0; k<1000;++k) {
-            mr.add(17*k);
-        }
-        ByteBuffer buffer = serializeRoaring(mr);
-        buffer.rewind();
-        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-        for(int k = 0; k<17*1000;++k) {
-            Assert.assertTrue(ir.contains(k) == (k/17*17==k));
-        }
+  @Test
+  public void testContains() throws IOException {
+    System.out.println("test contains");
+    MutableRoaringBitmap mr = new MutableRoaringBitmap();
+    for (int k = 0; k < 1000; ++k) {
+      mr.add(17 * k);
     }
-    
-
-    @Test
-    public void testContainsA() throws IOException {
-        System.out.println("test contains (runs too)");
-        MutableRoaringBitmap mr = new MutableRoaringBitmap();
-        for(int k = 0; k<1000;++k) {
-            mr.add(17*k);
-        }
-        for (int k = 200000; k < 210000; ++k)
-            if (k % 19 != 0)
-                mr.add(k);
-        mr.runOptimize();
-
-        ByteBuffer buffer = serializeRoaring(mr);
-        buffer.rewind();
-        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-        for(int k = 0; k<17*1000;++k) {
-            Assert.assertTrue(ir.contains(k) == (k/17*17==k));
-        }
+    ByteBuffer buffer = serializeRoaring(mr);
+    buffer.rewind();
+    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+    for (int k = 0; k < 17 * 1000; ++k) {
+      Assert.assertTrue(ir.contains(k) == (k / 17 * 17 == k));
     }
-    
+  }
 
-
-    @SuppressWarnings("resource")
-	static ByteBuffer serializeRoaring(ImmutableRoaringBitmap mrb) throws IOException {
-        byte[] backingArray = new byte[mrb.serializedSizeInBytes()+1024];
-			ByteBuffer outbb = ByteBuffer.wrap(backingArray, 1024, mrb.serializedSizeInBytes()).slice();
-			DataOutputStream dos = new DataOutputStream(new OutputStream(){
-	        ByteBuffer mBB;
-	        OutputStream init(ByteBuffer mbb) {mBB=mbb; return this;}
-	            @Override
-	            public void write(int b) {mBB.put((byte) b);}
-	            @Override
-	            public void write(byte[] b) {}
-	            @Override
-	            public void write(byte[] b, int off, int l) { mBB.put(b,off,l); }
-	        }.init(outbb));
-			mrb.serialize(dos);
-			dos.close();
-			
-
-			return outbb;
-	}
-
-
-
-	@Test
-	public void testHash() {
-		MutableRoaringBitmap rbm1 = new MutableRoaringBitmap();
-		rbm1.add(17);
-		MutableRoaringBitmap rbm2 = new MutableRoaringBitmap();
-		rbm2.add(17);
-		Assert.assertTrue(rbm1.hashCode() == rbm2.hashCode());
-		rbm2 = rbm1.clone();
-		Assert.assertTrue(rbm1.hashCode() == rbm2.hashCode());
-	}
-	
-    @Test
-    public void ANDNOTtest() {
-        final MutableRoaringBitmap rr = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k)
-            rr.add(k);
-        for (int k = 65536; k < 65536 + 4000; ++k)
-            rr.add(k);
-        for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
-            rr.add(k);
-        for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
-            rr.add(k);
-        for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
-            rr.add(k);
-        for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
-            rr.add(k);
-        for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
-            rr.add(k);
-
-        final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 65536; k < 65536 + 4000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
-            rr2.add(k);
-        }
-        final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
-        rr.andNot(rr2);
-        Assert.assertTrue(correct.equals(rr));
-        Assert.assertTrue(correct.hashCode() == rr.hashCode());
-
+  @Test
+  public void testContainsA() throws IOException {
+    System.out.println("test contains (runs too)");
+    MutableRoaringBitmap mr = new MutableRoaringBitmap();
+    for (int k = 0; k < 1000; ++k) {
+      mr.add(17 * k);
     }
+    for (int k = 200000; k < 210000; ++k)
+      if (k % 19 != 0)
+        mr.add(k);
+    mr.runOptimize();
 
-
-    @Test
-    public void ANDNOTtestA() {
-        // both have run containers
-        final MutableRoaringBitmap rr = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k)
-            rr.add(k);
-        for (int k = 65536; k < 65536 + 4000; ++k)
-            rr.add(k);
-        for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
-            rr.add(k);
-        for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
-            rr.add(k);
-        for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
-            rr.add(k);
-        for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
-            rr.add(k);
-        for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
-            rr.add(k);
-
-        rr.runOptimize();
-
-        final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 65536; k < 65536 + 4000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
-            rr2.add(k);
-        }
-        rr2.runOptimize();
-        final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
-        rr.andNot(rr2);
-        Assert.assertTrue(correct.equals(rr));
-        Assert.assertTrue(correct.hashCode() == rr.hashCode());
-
+    ByteBuffer buffer = serializeRoaring(mr);
+    buffer.rewind();
+    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+    for (int k = 0; k < 17 * 1000; ++k) {
+      Assert.assertTrue(ir.contains(k) == (k / 17 * 17 == k));
     }
+  }
 
-    @Test
-    public void ANDNOTtestB() {
-        // first one has run containers but not second.
-        final MutableRoaringBitmap rr = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k)
-            rr.add(k);
-        for (int k = 65536; k < 65536 + 4000; ++k)
-            rr.add(k);
-        for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
-            rr.add(k);
-        for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
-            rr.add(k);
-        for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
-            rr.add(k);
-        for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
-            rr.add(k);
-        for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
-            rr.add(k);
+  @SuppressWarnings("resource")
+  static ByteBuffer serializeRoaring(ImmutableRoaringBitmap mrb) throws IOException {
+    byte[] backingArray = new byte[mrb.serializedSizeInBytes() + 1024];
+    ByteBuffer outbb = ByteBuffer.wrap(backingArray, 1024, mrb.serializedSizeInBytes()).slice();
+    DataOutputStream dos = new DataOutputStream(new OutputStream() {
+      ByteBuffer mBB;
 
-        rr.runOptimize();
+      OutputStream init(ByteBuffer mbb) {
+        mBB = mbb;
+        return this;
+      }
 
-        final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 65536; k < 65536 + 4000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
-            rr2.add(k);
-        }
-        final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
-        rr.andNot(rr2);
-        Assert.assertTrue(correct.equals(rr));
-        Assert.assertTrue(correct.hashCode() == rr.hashCode());
+      @Override
+      public void write(int b) {
+        mBB.put((byte) b);
+      }
 
+      @Override
+      public void write(byte[] b) {
+      }
+
+      @Override
+      public void write(byte[] b, int off, int l) {
+        mBB.put(b, off, l);
+      }
+    }.init(outbb));
+    mrb.serialize(dos);
+    dos.close();
+
+    return outbb;
+  }
+
+  @Test
+  public void testHash() {
+    MutableRoaringBitmap rbm1 = new MutableRoaringBitmap();
+    rbm1.add(17);
+    MutableRoaringBitmap rbm2 = new MutableRoaringBitmap();
+    rbm2.add(17);
+    Assert.assertTrue(rbm1.hashCode() == rbm2.hashCode());
+    rbm2 = rbm1.clone();
+    Assert.assertTrue(rbm1.hashCode() == rbm2.hashCode());
+  }
+
+  @Test
+  public void ANDNOTtest() {
+    final MutableRoaringBitmap rr = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k)
+      rr.add(k);
+    for (int k = 65536; k < 65536 + 4000; ++k)
+      rr.add(k);
+    for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
+      rr.add(k);
+    for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
+      rr.add(k);
+    for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
+      rr.add(k);
+    for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
+      rr.add(k);
+    for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
+      rr.add(k);
+
+    final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k) {
+      rr2.add(k);
     }
-
-
-    @Test
-    public void ANDNOTtestC() {
-        // second has run containers, but not first
-        final MutableRoaringBitmap rr = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k)
-            rr.add(k);
-        for (int k = 65536; k < 65536 + 4000; ++k)
-            rr.add(k);
-        for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
-            rr.add(k);
-        for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
-            rr.add(k);
-        for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
-            rr.add(k);
-        for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
-            rr.add(k);
-        for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
-            rr.add(k);
-
-        final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 65536; k < 65536 + 4000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
-            rr2.add(k);
-        }
-        for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
-            rr2.add(k);
-        }
-        rr2.runOptimize();
-
-        final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
-        rr.andNot(rr2);
-        Assert.assertTrue(correct.equals(rr));
-        Assert.assertTrue(correct.hashCode() == rr.hashCode());
+    for (int k = 65536; k < 65536 + 4000; ++k) {
+      rr2.add(k);
     }
-
-
-
-
-
-    
-    @Test
-    public void MappeableContainersAccessTest() throws IOException {
-        MutableRoaringBitmap mr = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k)
-            mr.add(k);
-        for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
-            mr.add(k);
-        for (int k = (1 << 18); k < (1 << 18) + 9000; ++k)
-            mr.add(k);
-        for (int k = (1 << 19); k < (1 << 19) + 7000; ++k)
-            mr.add(k);
-        for (int k = (1 << 20); k < (1 << 20) + 10000; ++k)
-            mr.add(k);
-        for (int k = (1 << 23); k < (1 << 23) + 1000; ++k)
-            mr.add(k);
-        for (int k = (1 << 24); k < (1 << 24) + 30000; ++k)
-            mr.add(k);
-        ByteBuffer buffer = serializeRoaring(mr);
-        buffer.rewind();
-        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-        mr = ir.toMutableRoaringBitmap();
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableArrayContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableArrayContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableBitmapContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableBitmapContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableBitmapContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableArrayContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(6)) instanceof MappeableBitmapContainer);
-        
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality()==256);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality()==4000);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality()==9000);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality()==7000);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality()==10000);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality()==1000);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(6).getCardinality()==30000);
-        
-        MutableRoaringBitmap mr2 = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k)
-            mr2.add(k);
-        for (int k = (1 << 16); k < (1 << 16) + 4000; ++k) 
-            mr2.add(k);
-        for (int k = (1 << 18) + 2000; k < (1 << 18) + 8000; ++k) 
-            mr2.add(k);
-        for (int k = (1 << 21); k < (1 << 21) + 1000; ++k) 
-            mr2.add(k);
-        for (int k = (1 << 22); k < (1 << 22) + 2000; ++k)
-            mr2.add(k);
-        for (int k = (1 << 25); k < (1 << 25) + 5000; ++k)
-            mr2.add(k);        
-        buffer = serializeRoaring(mr2);
-        buffer.rewind();
-        ImmutableRoaringBitmap ir2 = new ImmutableRoaringBitmap(buffer);
-        mr2 = ir2.toMutableRoaringBitmap();
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableArrayContainer);
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableArrayContainer);
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableBitmapContainer);
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableArrayContainer);
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableArrayContainer);
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableBitmapContainer);
-        
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality()==256);
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality()==4000);
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality()==6000);
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality()==1000);
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality()==2000);
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality()==5000);
-        
-        MutableRoaringBitmap mr3 = new MutableRoaringBitmap();
-        buffer = serializeRoaring(mr3);
-        buffer.rewind();
-        ImmutableRoaringBitmap ir3 = new ImmutableRoaringBitmap(buffer);
-        mr3 = ir3.toMutableRoaringBitmap();
-        
-        Assert.assertTrue(mr3.getCardinality()==0);
+    for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
+      rr2.add(k);
     }
-
- @Test
-    public void MappeableContainersAccessTestA() throws IOException {
-     // run containers too
-        MutableRoaringBitmap mr = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k)
-            mr.add(k);
-        for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
-            mr.add(k);
-        for (int k = (1 << 18); k < (1 << 18) + 9000; ++k)
-            mr.add(k);
-        for (int k = (1 << 19); k < (1 << 19) + 7000; ++k)
-            mr.add(k);
-        for (int k = (1 << 20); k < (1 << 20) + 10000; ++k)
-            mr.add(k);
-        for (int k = (1 << 23); k < (1 << 23) + 1000; ++k)
-            mr.add(k);
-        for (int k = (1 << 24); k < (1 << 24) + 30000; ++k)
-            mr.add(k);
-        mr.runOptimize();
-        ByteBuffer buffer = serializeRoaring(mr);
-        buffer.rewind();
-        ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
-        mr = ir.toMutableRoaringBitmap();
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr.getMappeableRoaringArray().getContainerAtIndex(6)) instanceof MappeableRunContainer);
-        
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality()==256);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality()==4000);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality()==9000);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality()==7000);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality()==10000);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality()==1000);
-        Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(6).getCardinality()==30000);
-        
-        MutableRoaringBitmap mr2 = new MutableRoaringBitmap();
-        for (int k = 4000; k < 4256; ++k)
-            mr2.add(k);
-        for (int k = (1 << 16); k < (1 << 16) + 4000; ++k) 
-            mr2.add(k);
-        for (int k = (1 << 18) + 2000; k < (1 << 18) + 8000; ++k) 
-            mr2.add(k);
-        for (int k = (1 << 21); k < (1 << 21) + 1000; ++k) 
-            mr2.add(k);
-        for (int k = (1 << 22); k < (1 << 22) + 2000; ++k)
-            mr2.add(k);
-        for (int k = (1 << 25); k < (1 << 25) + 5000; ++k)
-            mr2.add(k);        
-        mr2.runOptimize();
-        buffer = serializeRoaring(mr2);
-        buffer.rewind();
-        ImmutableRoaringBitmap ir2 = new ImmutableRoaringBitmap(buffer);
-        mr2 = ir2.toMutableRoaringBitmap();
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableRunContainer);
-        Assert.assertTrue((Object)(mr2.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableRunContainer);
-        
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality()==256);
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality()==4000);
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality()==6000);
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality()==1000);
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality()==2000);
-        Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality()==5000);
-        
-        MutableRoaringBitmap mr3 = new MutableRoaringBitmap();
-        buffer = serializeRoaring(mr3);
-        buffer.rewind();
-        ImmutableRoaringBitmap ir3 = new ImmutableRoaringBitmap(buffer);
-        mr3 = ir3.toMutableRoaringBitmap();
-        
-        Assert.assertTrue(mr3.getCardinality()==0);
+    for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
+      rr2.add(k);
     }
-
-
-
-
-
-
-    @Test
-    public void andnottest4() {
-        final MutableRoaringBitmap rb = new MutableRoaringBitmap();
-        final MutableRoaringBitmap rb2 = new MutableRoaringBitmap();
-
-        for (int i = 0; i < 200000; i += 4)
-            rb2.add(i);
-        for (int i = 200000; i < 400000; i += 14)
-            rb2.add(i);
-        rb2.getCardinality();
-
-        // check op against an empty bitmap
-        final MutableRoaringBitmap andNotresult = MutableRoaringBitmap
-                .andNot(rb, rb2);
-        final MutableRoaringBitmap off = MutableRoaringBitmap.andNot(rb2, rb);
-
-        Assert.assertEquals(rb, andNotresult);
-        Assert.assertEquals(rb2, off);
-        rb2.andNot(rb);
-        Assert.assertEquals(rb2, off);
+    for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
+      rr2.add(k);
     }
-
-@Test
-    public void andnottest4A() {
-        final MutableRoaringBitmap rb = new MutableRoaringBitmap();
-        final MutableRoaringBitmap rb2 = new MutableRoaringBitmap();
-
-        for (int i = 0; i < 200000; i++)
-            if (i % 9 < 6) 
-                rb2.add(i);
-        for (int i = 200000; i < 400000; i += 14)
-            rb2.add(i);
-        rb2.getCardinality();
-        rb2.runOptimize();
-
-        // check against an empty bitmap
-        final MutableRoaringBitmap andNotresult = MutableRoaringBitmap
-                .andNot(rb, rb2);
-        final MutableRoaringBitmap off = MutableRoaringBitmap.andNot(rb2, rb);
-
-        Assert.assertEquals(rb, andNotresult);
-        Assert.assertEquals(rb2, off);
-        rb2.andNot(rb);
-        Assert.assertEquals(rb2, off);
+    for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
+      rr2.add(k);
     }
+    final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
+    rr.andNot(rr2);
+    Assert.assertTrue(correct.equals(rr));
+    Assert.assertTrue(correct.hashCode() == rr.hashCode());
+
+  }
+
+  @Test
+  public void ANDNOTtestA() {
+    // both have run containers
+    final MutableRoaringBitmap rr = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k)
+      rr.add(k);
+    for (int k = 65536; k < 65536 + 4000; ++k)
+      rr.add(k);
+    for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
+      rr.add(k);
+    for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
+      rr.add(k);
+    for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
+      rr.add(k);
+    for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
+      rr.add(k);
+    for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
+      rr.add(k);
+
+    rr.runOptimize();
+
+    final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 65536; k < 65536 + 4000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
+      rr2.add(k);
+    }
+    rr2.runOptimize();
+    final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
+    rr.andNot(rr2);
+    Assert.assertTrue(correct.equals(rr));
+    Assert.assertTrue(correct.hashCode() == rr.hashCode());
+
+  }
+
+  @Test
+  public void ANDNOTtestB() {
+    // first one has run containers but not second.
+    final MutableRoaringBitmap rr = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k)
+      rr.add(k);
+    for (int k = 65536; k < 65536 + 4000; ++k)
+      rr.add(k);
+    for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
+      rr.add(k);
+    for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
+      rr.add(k);
+    for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
+      rr.add(k);
+    for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
+      rr.add(k);
+    for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
+      rr.add(k);
+
+    rr.runOptimize();
+
+    final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 65536; k < 65536 + 4000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
+      rr2.add(k);
+    }
+    final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
+    rr.andNot(rr2);
+    Assert.assertTrue(correct.equals(rr));
+    Assert.assertTrue(correct.hashCode() == rr.hashCode());
+
+  }
+
+  @Test
+  public void ANDNOTtestC() {
+    // second has run containers, but not first
+    final MutableRoaringBitmap rr = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k)
+      rr.add(k);
+    for (int k = 65536; k < 65536 + 4000; ++k)
+      rr.add(k);
+    for (int k = 3 * 65536; k < 3 * 65536 + 9000; ++k)
+      rr.add(k);
+    for (int k = 4 * 65535; k < 4 * 65535 + 7000; ++k)
+      rr.add(k);
+    for (int k = 6 * 65535; k < 6 * 65535 + 10000; ++k)
+      rr.add(k);
+    for (int k = 8 * 65535; k < 8 * 65535 + 1000; ++k)
+      rr.add(k);
+    for (int k = 9 * 65535; k < 9 * 65535 + 30000; ++k)
+      rr.add(k);
+
+    final MutableRoaringBitmap rr2 = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 65536; k < 65536 + 4000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 3 * 65536 + 2000; k < 3 * 65536 + 6000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 6 * 65535; k < 6 * 65535 + 1000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 7 * 65535; k < 7 * 65535 + 1000; ++k) {
+      rr2.add(k);
+    }
+    for (int k = 10 * 65535; k < 10 * 65535 + 5000; ++k) {
+      rr2.add(k);
+    }
+    rr2.runOptimize();
+
+    final MutableRoaringBitmap correct = MutableRoaringBitmap.andNot(rr, rr2);
+    rr.andNot(rr2);
+    Assert.assertTrue(correct.equals(rr));
+    Assert.assertTrue(correct.hashCode() == rr.hashCode());
+  }
+
+  @Test
+  public void MappeableContainersAccessTest() throws IOException {
+    MutableRoaringBitmap mr = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k)
+      mr.add(k);
+    for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
+      mr.add(k);
+    for (int k = (1 << 18); k < (1 << 18) + 9000; ++k)
+      mr.add(k);
+    for (int k = (1 << 19); k < (1 << 19) + 7000; ++k)
+      mr.add(k);
+    for (int k = (1 << 20); k < (1 << 20) + 10000; ++k)
+      mr.add(k);
+    for (int k = (1 << 23); k < (1 << 23) + 1000; ++k)
+      mr.add(k);
+    for (int k = (1 << 24); k < (1 << 24) + 30000; ++k)
+      mr.add(k);
+    ByteBuffer buffer = serializeRoaring(mr);
+    buffer.rewind();
+    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+    mr = ir.toMutableRoaringBitmap();
+    Assert
+        .assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableArrayContainer);
+    Assert
+        .assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableArrayContainer);
+    Assert.assertTrue(
+        (Object) (mr.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableBitmapContainer);
+    Assert.assertTrue(
+        (Object) (mr.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableBitmapContainer);
+    Assert.assertTrue(
+        (Object) (mr.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableBitmapContainer);
+    Assert
+        .assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableArrayContainer);
+    Assert.assertTrue(
+        (Object) (mr.getMappeableRoaringArray().getContainerAtIndex(6)) instanceof MappeableBitmapContainer);
+
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality() == 256);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality() == 4000);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality() == 9000);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality() == 7000);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality() == 10000);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality() == 1000);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(6).getCardinality() == 30000);
+
+    MutableRoaringBitmap mr2 = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k)
+      mr2.add(k);
+    for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
+      mr2.add(k);
+    for (int k = (1 << 18) + 2000; k < (1 << 18) + 8000; ++k)
+      mr2.add(k);
+    for (int k = (1 << 21); k < (1 << 21) + 1000; ++k)
+      mr2.add(k);
+    for (int k = (1 << 22); k < (1 << 22) + 2000; ++k)
+      mr2.add(k);
+    for (int k = (1 << 25); k < (1 << 25) + 5000; ++k)
+      mr2.add(k);
+    buffer = serializeRoaring(mr2);
+    buffer.rewind();
+    ImmutableRoaringBitmap ir2 = new ImmutableRoaringBitmap(buffer);
+    mr2 = ir2.toMutableRoaringBitmap();
+    Assert.assertTrue(
+        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableArrayContainer);
+    Assert.assertTrue(
+        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableArrayContainer);
+    Assert.assertTrue(
+        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableBitmapContainer);
+    Assert.assertTrue(
+        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableArrayContainer);
+    Assert.assertTrue(
+        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableArrayContainer);
+    Assert.assertTrue(
+        (Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableBitmapContainer);
+
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality() == 256);
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality() == 4000);
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality() == 6000);
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality() == 1000);
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality() == 2000);
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality() == 5000);
+
+    MutableRoaringBitmap mr3 = new MutableRoaringBitmap();
+    buffer = serializeRoaring(mr3);
+    buffer.rewind();
+    ImmutableRoaringBitmap ir3 = new ImmutableRoaringBitmap(buffer);
+    mr3 = ir3.toMutableRoaringBitmap();
+
+    Assert.assertTrue(mr3.getCardinality() == 0);
+  }
+
+  @Test
+  public void MappeableContainersAccessTestA() throws IOException {
+    // run containers too
+    MutableRoaringBitmap mr = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k)
+      mr.add(k);
+    for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
+      mr.add(k);
+    for (int k = (1 << 18); k < (1 << 18) + 9000; ++k)
+      mr.add(k);
+    for (int k = (1 << 19); k < (1 << 19) + 7000; ++k)
+      mr.add(k);
+    for (int k = (1 << 20); k < (1 << 20) + 10000; ++k)
+      mr.add(k);
+    for (int k = (1 << 23); k < (1 << 23) + 1000; ++k)
+      mr.add(k);
+    for (int k = (1 << 24); k < (1 << 24) + 30000; ++k)
+      mr.add(k);
+    mr.runOptimize();
+    ByteBuffer buffer = serializeRoaring(mr);
+    buffer.rewind();
+    ImmutableRoaringBitmap ir = new ImmutableRoaringBitmap(buffer);
+    mr = ir.toMutableRoaringBitmap();
+    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableRunContainer);
+    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableRunContainer);
+    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableRunContainer);
+    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableRunContainer);
+    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableRunContainer);
+    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableRunContainer);
+    Assert.assertTrue((Object) (mr.getMappeableRoaringArray().getContainerAtIndex(6)) instanceof MappeableRunContainer);
+
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality() == 256);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality() == 4000);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality() == 9000);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality() == 7000);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality() == 10000);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality() == 1000);
+    Assert.assertTrue(mr.getMappeableRoaringArray().getContainerAtIndex(6).getCardinality() == 30000);
+
+    MutableRoaringBitmap mr2 = new MutableRoaringBitmap();
+    for (int k = 4000; k < 4256; ++k)
+      mr2.add(k);
+    for (int k = (1 << 16); k < (1 << 16) + 4000; ++k)
+      mr2.add(k);
+    for (int k = (1 << 18) + 2000; k < (1 << 18) + 8000; ++k)
+      mr2.add(k);
+    for (int k = (1 << 21); k < (1 << 21) + 1000; ++k)
+      mr2.add(k);
+    for (int k = (1 << 22); k < (1 << 22) + 2000; ++k)
+      mr2.add(k);
+    for (int k = (1 << 25); k < (1 << 25) + 5000; ++k)
+      mr2.add(k);
+    mr2.runOptimize();
+    buffer = serializeRoaring(mr2);
+    buffer.rewind();
+    ImmutableRoaringBitmap ir2 = new ImmutableRoaringBitmap(buffer);
+    mr2 = ir2.toMutableRoaringBitmap();
+    Assert
+        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(0)) instanceof MappeableRunContainer);
+    Assert
+        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(1)) instanceof MappeableRunContainer);
+    Assert
+        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(2)) instanceof MappeableRunContainer);
+    Assert
+        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(3)) instanceof MappeableRunContainer);
+    Assert
+        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(4)) instanceof MappeableRunContainer);
+    Assert
+        .assertTrue((Object) (mr2.getMappeableRoaringArray().getContainerAtIndex(5)) instanceof MappeableRunContainer);
+
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(0).getCardinality() == 256);
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(1).getCardinality() == 4000);
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(2).getCardinality() == 6000);
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(3).getCardinality() == 1000);
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(4).getCardinality() == 2000);
+    Assert.assertTrue(mr2.getMappeableRoaringArray().getContainerAtIndex(5).getCardinality() == 5000);
+
+    MutableRoaringBitmap mr3 = new MutableRoaringBitmap();
+    buffer = serializeRoaring(mr3);
+    buffer.rewind();
+    ImmutableRoaringBitmap ir3 = new ImmutableRoaringBitmap(buffer);
+    mr3 = ir3.toMutableRoaringBitmap();
+
+    Assert.assertTrue(mr3.getCardinality() == 0);
+  }
+
+  @Test
+  public void andnottest4() {
+    final MutableRoaringBitmap rb = new MutableRoaringBitmap();
+    final MutableRoaringBitmap rb2 = new MutableRoaringBitmap();
+
+    for (int i = 0; i < 200000; i += 4)
+      rb2.add(i);
+    for (int i = 200000; i < 400000; i += 14)
+      rb2.add(i);
+    rb2.getCardinality();
+
+    // check op against an empty bitmap
+    final MutableRoaringBitmap andNotresult = MutableRoaringBitmap.andNot(rb, rb2);
+    final MutableRoaringBitmap off = MutableRoaringBitmap.andNot(rb2, rb);
+
+    Assert.assertEquals(rb, andNotresult);
+    Assert.assertEquals(rb2, off);
+    rb2.andNot(rb);
+    Assert.assertEquals(rb2, off);
+  }
+
+  @Test
+  public void andnottest4A() {
+    final MutableRoaringBitmap rb = new MutableRoaringBitmap();
+    final MutableRoaringBitmap rb2 = new MutableRoaringBitmap();
+
+    for (int i = 0; i < 200000; i++)
+      if (i % 9 < 6)
+        rb2.add(i);
+    for (int i = 200000; i < 400000; i += 14)
+      rb2.add(i);
+    rb2.getCardinality();
+    rb2.runOptimize();
+
+    // check against an empty bitmap
+    final MutableRoaringBitmap andNotresult = MutableRoaringBitmap.andNot(rb, rb2);
+    final MutableRoaringBitmap off = MutableRoaringBitmap.andNot(rb2, rb);
+
+    Assert.assertEquals(rb, andNotresult);
+    Assert.assertEquals(rb2, off);
+    rb2.andNot(rb);
+    Assert.assertEquals(rb2, off);
+  }
 
   @Test
   public void fliptest1() {
@@ -800,6 +808,50 @@ public class TestImmutableRoaringBitmap {
     result.add(1);
 
     Assert.assertEquals(result, rb2);
+  }
+
+  @Test
+  public void testRangedOr() {
+    int length = 1000;
+    int NUM_ITER = 10;
+    Random random = new Random();
+
+    final MutableRoaringBitmap rb1 = new MutableRoaringBitmap();
+    final MutableRoaringBitmap rb2 = new MutableRoaringBitmap();
+    Set<Integer> set1 = new HashSet<>();
+    Set<Integer> set2 = new HashSet<>();
+    int numBitsToSet = length / 2;
+    for (int i = 0; i < numBitsToSet; i++) {
+      int val1 = random.nextInt(length);
+      int val2 = random.nextInt(length);
+
+      rb1.add(val1);
+      set1.add(val1);
+
+      rb2.add(val2);
+      set2.add(val2);
+    }
+    Set<Integer> unionSet = new TreeSet<>();
+    unionSet.addAll(set1);
+    unionSet.addAll(set2);
+    for (int iter = 0; iter < NUM_ITER; iter++) {
+      int rangeStart = random.nextInt(length - 1);
+      int rangeEnd = rangeStart + random.nextInt(length - rangeStart) + 1;// +1 to ensure rangeEnd >rangeStart, may
+      Set<Integer> expectedResultSet = new TreeSet<>();
+      for (int i = rangeStart; i < rangeEnd; i++) {
+        if (unionSet.contains(i)) {
+          expectedResultSet.add(i);
+        }
+      }
+      MutableRoaringBitmap result = ImmutableRoaringBitmap.ranged_or(rb1, rb2, rangeStart, rangeEnd);
+      Set<Integer> actualResultSet = new TreeSet<>();
+      IntIterator intIterator = result.getIntIterator();
+      while (intIterator.hasNext()) {
+        actualResultSet.add(intIterator.next());
+      }
+
+      Assert.assertEquals(expectedResultSet, actualResultSet);
+    }
   }
 
 }


### PR DESCRIPTION
I might have fixed the selectRangeWithoutCopy.

More testing, benchmarks and documentation (comments) are needed.

I can see your changes to TestImmutableRoaringBitmap.java and they are fine I think...

https://github.com/kishoreg/RoaringBitmap/commit/a51db4c6ab893237b04520a4dff27f0567d2c237?w=1

Note that you appear to have reformatted the file, something I would recommend against when doing a PR, since  by default we get the following message...

`777 additions, 725 deletions not shown because the diff is too large. Please use a local Git client to view these changes.`

https://github.com/kishoreg/RoaringBitmap/commit/a51db4c6ab893237b04520a4dff27f0567d2c237

So I propose to remove these white-space changes.
